### PR TITLE
Add webhook notifications from microsoft teams

### DIFF
--- a/.github/workflows/send-reminders.yml
+++ b/.github/workflows/send-reminders.yml
@@ -1,0 +1,19 @@
+name: Send Tour Reminders to Teams
+
+on:
+  schedule:
+    - cron: '0 14 * * *'  # 8:00 AM Costa Rica (UTC-6) = 14:00 UTC
+  workflow_dispatch:  # Allow manual runs for testing
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger reminder endpoint
+        run: |
+          curl -X POST "${{ secrets.SITE_URL }}/api/send-reminders" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            -H "Content-Type: application/json" \
+            --fail \
+            --silent \
+            --show-error

--- a/README.md
+++ b/README.md
@@ -1,84 +1,203 @@
 # Tropicalización de la Tecnología - UCR
 
-Este repositorio contiene una aplicación hecha con Firebase para el frontend y python para el backend del simulador
-
-## Cómo ejecutar el proyecto
-
-### Importante: ejecutar ambos servidores
-
-Este proyecto requiere ejecutar **DOS servidores** al mismo tiempo:
-
-1. Backend (FastAPI) - Puerto 8000  
-2. Frontend (Next.js) - Puerto 9002  
-
-Se necesitan dos terminales separadas, una para cada servidor.
+Este repositorio contiene una aplicación hecha con Firebase para el frontend y Python para el backend del simulador.
 
 > [!NOTE]
-> Esto es temporal. Cuando el simulador esté listo, todo se integrará como un único proyecto que se ejecute al mismo tiempo.
+> El simulador está en desarrollo. Cuando esté listo, backend y frontend se integrarán en un único servidor.
+
+## Índice
+
+- [Inicio rápido](#inicio-rápido)
+- [Configuración inicial](#configuración-inicial)
+  - [Requisitos](#requisitos)
+  - [Instalar dependencias](#instalar-dependencias)
+  - [Configurar entorno](#configurar-entorno)
+  - [Autenticar Firebase CLI](#autenticar-firebase-cli)
+- [Cómo ejecutar](#cómo-ejecutar)
+  - [1. Firebase Emulators](#1-firebase-emulators)
+  - [2. Backend](#2-backend)
+  - [3. Frontend](#3-frontend)
+- [Referencia técnica](#referencia-técnica)
+  - [API del backend](#api-del-backend)
+  - [Variables de entorno](#variables-de-entorno)
+  - [Sistema de notificaciones Teams](#sistema-de-notificaciones-teams)
+  - [Uso del simulador](#uso-del-simulador)
 
 ---
 
-### Configuración y ejecución del Backend
+## Inicio rápido
 
-#### Configuración inicial (primera vez)
+Para colaboradores que ya tienen todo configurado. Se necesitan **tres terminales**.
 
-1. Ir al directorio `backend`:
-````bash
-cd backend
-````
-
-2. Crear un entorno virtual de Python:
 ```bash
-python3 -m venv venv
+# Terminal 1 — Firebase Emulators
+firebase emulators:start --import=.firebase/emulator-data --export-on-exit --project demo-tropicalizacion
 ```
 
-3. Activar el entorno virtual:
 ```bash
-source venv/bin/activate
-```
-
-4. Instalar las dependencias:
-```bash
-pip install -r requirements.txt
-```
-
-#### Ejecutar el servidor Backend
-
-1. Activar el entorno virtual (si no está activado):
-```bash
+# Terminal 2 — Backend (FastAPI)
 cd backend
 source venv/bin/activate
-```
-
-En caso de tener problemas con la activación de numpy/pandas, también se puede usar:
-```bash
-pip install --upgrade --force-reinstall numpy pandas
-```
-
-2. Iniciar el servidor FastAPI:
-```bash
 python -m uvicorn main:app --reload
 ```
 
-El servidor quedará en: http://127.0.0.1:8000
-
-#### Cómo probar el Backend
-**Opción 1: documentación interactiva de la API**
-
-- Abrir en el navegador: http://127.0.0.1:8000/docs
-Incluye Swagger UI para probar endpoints de forma interactiva.
-
-**Opción 2: probar el endpoint raíz**
-
-- Abrir: http://127.0.0.1:8000/
-O usar: curl http://127.0.0.1:8000/
-
-**Opción 3: probar endpoints con curl**
 ```bash
-# Probar endpoint raíz
+# Terminal 3 — Frontend (Next.js)
+npm run dev
+```
+
+| Servicio | URL |
+|----------|-----|
+| Frontend | http://localhost:9002 |
+| Backend | http://127.0.0.1:8000 |
+| Emulator UI | http://localhost:4000 |
+
+---
+
+## Configuración inicial
+
+Pasos para configurar el proyecto por primera vez.
+
+### Requisitos
+
+| Herramienta | Versión mínima | Notas |
+|-------------|---------------|-------|
+| Node.js | 20+ | |
+| Java JDK | 21 | Requerido por Firestore Emulator |
+| Python | 3.x | Para el backend FastAPI |
+| Firebase CLI | última | Instalar con `npm install -g firebase-tools` |
+
+En Ubuntu/Debian:
+
+```bash
+sudo apt update
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+sudo apt install -y openjdk-21-jdk
+```
+
+### Instalar dependencias
+
+**Frontend (Node.js) — desde la raíz del proyecto:**
+
+```bash
+npm install
+```
+
+**Backend (Python) — desde el directorio `backend/`:**
+
+```bash
+cd backend
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+> Si hay problemas con numpy/pandas: `pip install --upgrade --force-reinstall numpy pandas`
+
+### Configurar entorno
+
+Crear un archivo `.env.development` en la raíz del proyecto:
+
+```env
+NEXT_PUBLIC_FIREBASE_API_KEY=AIzaSyDemo...
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=demo-tropicalizacion.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=demo-tropicalizacion
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=demo-tropicalizacion.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=123456789
+NEXT_PUBLIC_FIREBASE_APP_ID=1:123456789:web:abc123xyz
+NEXT_PUBLIC_USE_FIREBASE_EMULATORS=true
+
+# Notificaciones Teams (opcional en desarrollo; dejar en blanco para deshabilitar)
+TEAMS_WEBHOOK_URL=
+CRON_SECRET=anythingyouwant
+NEXT_PUBLIC_SITE_URL=http://localhost:9002
+SITE_URL=http://localhost:9002
+```
+
+- `NEXT_PUBLIC_USE_FIREBASE_EMULATORS=true` es obligatorio en desarrollo.
+- `TEAMS_WEBHOOK_URL` puede dejarse vacío; `postToTeams` se deshabilita automáticamente si no está definida.
+- Reiniciar el servidor Next.js si se cambia `.env.development`.
+
+### Autenticar Firebase CLI
+
+```bash
+npm install -g firebase-tools
+firebase login
+```
+
+---
+
+## Cómo ejecutar
+
+El proyecto requiere **tres servidores** corriendo en paralelo. Abrir una terminal por servidor, en este orden.
+
+### 1. Firebase Emulators
+
+Iniciar **primero**, antes del backend y el frontend.
+
+```bash
+firebase emulators:start --import=.firebase/emulator-data --export-on-exit --project demo-tropicalizacion
+```
+
+Los emuladores se levantan en:
+
+| Servicio | Puerto |
+|----------|--------|
+| Auth | 9099 |
+| Firestore | 8080 |
+| Storage | 9199 |
+| Emulator UI | 4000 (por defecto) |
+
+Los datos persisten entre reinicios en `.firebase/emulator-data/` (no está en control de versiones). Para limpiar todos los datos:
+
+```bash
+rm -rf .firebase/emulator-data
+firebase emulators:start --project demo-tropicalizacion
+```
+
+### 2. Backend
+
+```bash
+cd backend
+source venv/bin/activate
+python -m uvicorn main:app --reload
+```
+
+Servidor disponible en: http://127.0.0.1:8000
+
+### 3. Frontend
+
+```bash
+npm run dev
+```
+
+Servidor disponible en: http://localhost:9002
+
+---
+
+## Referencia técnica
+
+### API del backend
+
+**Documentación interactiva (Swagger UI):** http://127.0.0.1:8000/docs
+
+#### Endpoints
+
+| Método | Ruta | Descripción |
+|--------|------|-------------|
+| `GET` | `/` | Confirma que la API está activa |
+| `POST` | `/api/v1/upload` | Subir un archivo CSV con perfil de potencia |
+| `POST` | `/api/v1/upload-multiple` | Subir múltiples CSV con diferentes perfiles |
+| `POST` | `/api/v1/simulate` | Ejecutar simulación de microred |
+
+#### Ejemplos con curl
+
+```bash
+# Endpoint raíz
 curl http://127.0.0.1:8000/
 
-# Subir un archivo CSV
+# Subir un CSV
 curl -X POST http://127.0.0.1:8000/api/v1/upload \
   -F "file=@backend/tests/test_power_data.csv"
 
@@ -88,25 +207,14 @@ curl -X POST http://127.0.0.1:8000/api/v1/upload-multiple \
   -F "files=@backend/tests/test_power_profile.csv" \
   -F "files=@backend/tests/test.csv"
 
-# Ejecutar simulación (ajustar payload según necesidad)
+# Ejecutar simulación
 curl -X POST http://127.0.0.1:8000/api/v1/simulate \
   -H "Content-Type: application/json" \
   -d '{"your": "data"}'
 ```
 
-Endpoints disponibles
-- ``GET /`` - Endpoint raíz, confirma que la API está activa
-- ``POST /api/v1/upload`` - Subir un archivo CSV con perfil de potencia
-- ``POST /api/v1/upload-multiple`` - Subir múltiples CSV con diferentes perfiles de potencia (p. ej. PV, viento, demanda)
-- ``POST /api/v1/simulate`` - Ejecutar simulación de microred
+#### Formato CSV esperado
 
-**Uso de carga múltiple de CSV**
-
-El endpoint **/api/v1/upload-multiple** permite subir varios archivos CSV en una sola solicitud. Esto es útil cuando hay archivos separados para distintos perfiles (por ejemplo, generación solar, generación eólica y demanda).
-
-Formato esperado para cada CSV:
-
-Ejemplo de respuesta:
 ```
 timestamp,power
 2023-10-09 00:00:00,100.5
@@ -114,10 +222,9 @@ timestamp,power
 ...
 ```
 
+Respuesta de `/api/v1/upload-multiple`:
 
-La respuesta incluye:
-
-```
+```json
 {
   "time": ["2023-10-09 00:00:00", "2023-10-09 00:15:00", "..."],
   "profiles": {
@@ -128,32 +235,101 @@ La respuesta incluye:
 }
 ```
 
-- ``time``: arreglo de timestamps (tomado del primer archivo)
-- ``profiles``: diccionario que mapea cada nombre de archivo (sin .csv) con su arreglo de potencias
+- `time`: timestamps del primer archivo
+- `profiles`: potencias por archivo (clave = nombre del archivo sin `.csv`)
+- Todos los CSV deben tener los mismos timestamps.
 
-**Nota**: Todos los CSV deben tener los mismos timestamps. El sistema usa el primer archivo como referencia temporal.
+### Variables de entorno
 
-### Configuración y ejecución del Frontend
+El proyecto usa dos archivos:
 
-**Configuración inicial (primera vez)**
-1. Instalar dependencias de Node.js:
+| Archivo | Cuándo aplica |
+|---------|--------------|
+| `.env.development` | `npm run dev` (emuladores locales) |
+| `.env.production` | Build de producción / Firebase App Hosting |
+
+#### Firebase (expuestas al navegador)
+
+| Variable | Descripción |
+|----------|-------------|
+| `NEXT_PUBLIC_FIREBASE_API_KEY` | API key del proyecto Firebase |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | Dominio de autenticación Firebase |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | ID del proyecto Firebase |
+| `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | Bucket de Firebase Storage |
+| `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | Sender ID de Firebase Messaging |
+| `NEXT_PUBLIC_FIREBASE_APP_ID` | App ID de Firebase |
+| `NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID` | ID de Google Analytics (opcional) |
+| `NEXT_PUBLIC_USE_FIREBASE_EMULATORS` | `true` para usar emuladores locales |
+
+#### ImageKit (CDN de imágenes)
+
+| Variable | Descripción |
+|----------|-------------|
+| `IMAGEKIT_PUBLIC_KEY` | Clave pública de ImageKit |
+| `IMAGEKIT_PRIVATE_KEY` | Clave privada (**solo servidor, nunca exponer al cliente**) |
+| `NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT` | URL base del endpoint de ImageKit |
+
+#### Email
+
+| Variable | Descripción |
+|----------|-------------|
+| `RESEND_API_KEY` | API key de Resend (**solo servidor**) |
+
+#### Notificaciones Teams
+
+| Variable | Dónde configurar | Descripción |
+|----------|-----------------|-------------|
+| `TEAMS_WEBHOOK_URL` | `.env.production` + Firebase App Hosting secrets | URL del Incoming Webhook. Si está vacía, las notificaciones se deshabilitan sin errores. |
+| `CRON_SECRET` | `.env.production` + Firebase App Hosting secrets + GitHub Actions secrets | Token que autentica las llamadas del cron a `/api/send-reminders`. Generar con `openssl rand -hex 32`. |
+| `NEXT_PUBLIC_SITE_URL` | `.env.production` | URL base del sitio (ej. `https://web-tropicalizacion.web.app`). |
+| `SITE_URL` | GitHub Actions secrets | Misma URL que `NEXT_PUBLIC_SITE_URL`, usada por el workflow de GitHub Actions. |
+
+### Sistema de notificaciones Teams
+
+Cuando un profesor publica una gira, proyecto o artículo, se envía una tarjeta Adaptive Card al canal de Teams configurado. Además, un cron diario de GitHub Actions envía recordatorios 7 días antes de cada gira próxima.
+
+#### Configurar el Incoming Webhook
+
+1. Canal de Teams → `···` → **Connectors**
+2. Buscar **Incoming Webhook** → **Agregar** → **Configurar**
+3. Asignar un nombre (ej. "TCU-691 Actividades") → **Crear** → copiar la URL
+4. Guardar la URL como `TEAMS_WEBHOOK_URL` en `.env.production` y en los secretos de Firebase App Hosting
+
+#### Configurar secretos en GitHub Actions
+
+En **Settings → Secrets and variables → Actions** del repositorio:
+
+| Secreto | Valor |
+|---------|-------|
+| `SITE_URL` | URL de producción (ej. `https://web-tropicalizacion.web.app`) |
+| `CRON_SECRET` | Mismo valor que `CRON_SECRET` en `.env.production` |
+
+El workflow (`.github/workflows/send-reminders.yml`) se ejecuta diariamente a las **8:00 AM hora de Costa Rica** (14:00 UTC) y puede activarse manualmente desde la pestaña **Actions** del repositorio.
+
+#### Campo `dateISO` en giras
+
+Las giras tienen dos campos de fecha:
+
+- **`date`** — texto libre para mostrar al usuario (ej. "25 de Octubre, 2024")
+- **`dateISO`** — formato `YYYY-MM-DD` (ej. "2024-10-25"), usado exclusivamente por el cron
+
+Las giras sin `dateISO` son ignoradas por el cron. Las nuevas giras requieren ambos campos en el formulario de creación.
+
+#### Probar localmente
+
 ```bash
-cd frontend
-npm install
+# Notificación de nueva gira
+curl -X POST http://localhost:9002/api/notify \
+  -H "Content-Type: application/json" \
+  -d '{"type":"tour","id":"test","title":"Gira Test","description":"Una gira de prueba","slug":"gira-test","date":"25 Mayo 2026","location":"San José"}'
+
+# Endpoint de recordatorios
+curl -X POST http://localhost:9002/api/send-reminders \
+  -H "Authorization: Bearer anythingyouwant"
 ```
 
-2. Crear archivo de entorno (si hace falta):
+### Uso del simulador
 
-
-Luego configurar las variables de entorno.
-```bash
-npm run dev
-```
-
-Ejecutar el Frontend
-El frontend quedará en: http://localhost:9002
-
-Uso del simulador
 1. Ir a: http://localhost:9002/upload-profiles
 2. Seleccionar o arrastrar múltiples archivos CSV
 3. Para cada archivo, indicar qué representa:
@@ -162,80 +338,5 @@ Uso del simulador
    - Generación eólica
    - Generación hidroeléctrica
    - Otro (con etiqueta personalizada)
-4. Hacer clic en Upload files
+4. Hacer clic en **Upload files**
 5. Ver los resultados con todos los perfiles cargados
-
-## Preparación de Firebase Emulators (local)
-
-> Ejecutar estos pasos desde la raíz del proyecto (donde está `firebase.json`).
-
-### 1) Requisitos
-
-- Node.js 20+  
-- Firebase CLI  
-- Java JDK 21 (requerido por Firestore Emulator)
-
-### 2) Instalar dependencias del sistema (Ubuntu/Debian)
-
-```bash
-sudo apt update
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-sudo apt-get install -y nodejs
-sudo apt install -y openjdk-21-jdk
-java -version
-```
-
-### 3) Instalar Firebase CLI y autenticar
-
-```bash
-npm install -g firebase-tools
-which firebase
-firebase login
-firebase
-```
-
-### 4) **Crear/verifica `.env.development`** en la raíz del proyecto:
-
-  ```env
-  NEXT_PUBLIC_FIREBASE_API_KEY=AIzaSyDemo...
-  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=demo-tropicalizacion.firebaseapp.com
-  NEXT_PUBLIC_FIREBASE_PROJECT_ID=demo-tropicalizacion
-  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=demo-tropicalizacion.appspot.com
-  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=123456789
-  NEXT_PUBLIC_FIREBASE_APP_ID=1:123456789:web:abc123xyz
-  NEXT_PUBLIC_USE_FIREBASE_EMULATORS=true
-  ```
-
-- **`NEXT_PUBLIC_USE_FIREBASE_EMULATORS=true`** es obligatorio para modo desarrollo.
-- Reiniciar el servidor Next.js si se cambia `.env.development`.
-
-### 5) Levantar emuladores
-
-```bash
-firebase emulators:start --import=.firebase/emulator-data --export-on-exit --project demo-tropicalizacion
-```
-
-Según `firebase.json`, se levantan en:
-
-- Auth: `9099`
-- Firestore: `8080`
-- Storage: `9199`
-- Emulator UI: habilitada (puerto automático)
-
-
-Por defecto, los emuladores **no guardan datos** entre reinicios. Para habilitar persistencia:
-
-1. En `firebase.json`, configurar con:
-   ```json
-   "firestoreExportOnExit": true
-   ```
-
-2. Los datos se guardan en `.firebase/emulator-data/`
-
-3. Para **limpiar todos los datos** (reiniciar emuladores vacíos):
-   ```bash
-   rm -rf .firebase/emulator-data
-   firebase emulators:start --project demo-tropicalizacion
-   ```
-
-**Nota**: Esta persistencia es **solo local** para desarrollo.

--- a/src/app/api/notify/route.ts
+++ b/src/app/api/notify/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { postToTeams } from '@/lib/notifications';
+import { NotifyPayload } from '@/types/notification';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+
+    // Validate that type is one of the allowed values
+    const validTypes = ['tour', 'article', 'project'];
+    if (!body.type || !validTypes.includes(body.type)) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+
+    // Call postToTeams (it swallows errors internally)
+    await postToTeams(body as NotifyPayload);
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Error in /api/notify:', error);
+    return NextResponse.json({ error: 'Something went wrong' }, { status: 500 });
+  }
+}

--- a/src/app/api/send-reminders/route.ts
+++ b/src/app/api/send-reminders/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { collection, query, where, getDocs, doc, getDoc, setDoc, Timestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { postToTeams } from '@/lib/notifications';
+import type { FirestoreTour } from '@/types/tour';
+
+export async function POST(req: NextRequest) {
+  // Auth check
+  const authHeader = req.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    if (!db) {
+      return NextResponse.json({ error: 'DB not initialized' }, { status: 500 });
+    }
+
+    // Compute target date: today + 7 days in YYYY-MM-DD UTC
+    const targetDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+
+    // Query upcoming tours
+    const toursQuery = query(
+      collection(db, 'tours'),
+      where('status', '==', 'Próximamente')
+    );
+    const toursSnap = await getDocs(toursQuery);
+
+    let sent = 0;
+
+    for (const tourDoc of toursSnap.docs) {
+      const tour = tourDoc.data() as FirestoreTour;
+
+      // Skip tours without a machine-readable date
+      if (!tour.dateISO) continue;
+
+      // Skip tours not matching the 7-day window
+      if (tour.dateISO !== targetDate) continue;
+
+      // Skip if reminder already sent
+      const sentRef = doc(db, 'remindersSent', `${tourDoc.id}_7d`);
+      const sentSnap = await getDoc(sentRef);
+      if (sentSnap.exists()) continue;
+
+      // Post reminder to Teams
+      await postToTeams({
+        type: 'tour',
+        id: tourDoc.id,
+        title: `🗓️ Recordatorio (7 días): ${tour.title}`,
+        description: tour.description,
+        slug: tour.slug,
+        date: tour.date,
+        location: tour.location,
+      });
+
+      // Mark as sent to prevent duplicates
+      await setDoc(sentRef, {
+        tourId: tourDoc.id,
+        type: 'reminder_7d',
+        sentAt: Timestamp.now(),
+      });
+
+      sent++;
+    }
+
+    return NextResponse.json({ sent });
+  } catch (error) {
+    console.error('[send-reminders] Error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/send-reminders/route.ts
+++ b/src/app/api/send-reminders/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: NextRequest) {
       if (tour.dateISO !== targetDate) continue;
 
       // Skip if reminder already sent
-      const sentRef = doc(db, 'remindersSent', `${tourDoc.id}_7d`);
+      const sentRef = doc(db, 'remindersSent', `${tourDoc.id}_7d_${tour.dateISO}`);
       const sentSnap = await getDoc(sentRef);
       if (sentSnap.exists()) continue;
 
@@ -61,6 +61,7 @@ export async function POST(req: NextRequest) {
         tourId: tourDoc.id,
         type: 'reminder_7d',
         sentAt: Timestamp.now(),
+        dateISO: tour.dateISO,
       });
 
       sent++;

--- a/src/app/api/send-reminders/route.ts
+++ b/src/app/api/send-reminders/route.ts
@@ -54,6 +54,7 @@ export async function POST(req: NextRequest) {
         slug: tour.slug,
         date: tour.date,
         location: tour.location,
+        imageUrl: tour.imageUrl,
       });
 
       // Mark as sent to prevent duplicates

--- a/src/app/crear-anuncio/page.tsx
+++ b/src/app/crear-anuncio/page.tsx
@@ -124,7 +124,17 @@ export default function CrearAnuncioPage() {
         articleData.linkUrl = data.linkUrl;
       }
       
-      await addDoc(collection(db, 'articles'), articleData);
+      const docRef = await addDoc(collection(db, 'articles'), articleData);
+      fetch('/api/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'article',
+          id: docRef.id,
+          title: data.title,
+          description: data.description,
+        }),
+      }).catch(console.error);
 
       toast({
         title: '¡Anuncio Creado!',

--- a/src/app/crear-anuncio/page.tsx
+++ b/src/app/crear-anuncio/page.tsx
@@ -133,6 +133,7 @@ export default function CrearAnuncioPage() {
           id: docRef.id,
           title: data.title,
           description: data.description,
+          imageUrl: imageUrl,
         }),
       }).catch(console.error);
 

--- a/src/app/profesor/panel-giras/crear/page.tsx
+++ b/src/app/profesor/panel-giras/crear/page.tsx
@@ -31,6 +31,7 @@ const tourSchema = z.object({
   location: z.string().min(3, { message: 'La ubicación es obligatoria.' }),
   date: z.string().min(1, { message: 'La fecha es obligatoria.' }),
   status: z.enum(['Próximamente', 'Realizada', 'Cancelada'], { required_error: 'Por favor selecciona un estado.' }),
+  dateISO: z.string().min(1, { message: 'La fecha ISO es obligatoria.' }),
   imageUrl: z
     .custom<FileList>()
     .refine((files) => files?.length === 1, "La imagen de portada es obligatoria.")
@@ -88,6 +89,7 @@ export default function CrearGiraPage() {
       location: '',
       date: '',
       status: undefined,
+      dateISO: '',
       imageUrl: undefined,
     },
   });
@@ -126,7 +128,20 @@ export default function CrearGiraPage() {
       };
       
       assertDb(db);
-      await addDoc(collection(db, 'tours'), tourDataToSave);
+      const docRef = await addDoc(collection(db, 'tours'), { ...tourDataToSave, dateISO: data.dateISO });
+      fetch('/api/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'tour',
+          id: docRef.id,
+          title: data.title,
+          description: data.description,
+          slug: slug,
+          date: data.date,
+          location: data.location,
+        }),
+      }).catch(console.error);
 
       toast({
         title: "Gira Creada",
@@ -187,6 +202,7 @@ export default function CrearGiraPage() {
                     <CardContent className="space-y-8">
                         <FormField control={form.control} name="title" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><Info className="mr-2 h-4 w-4"/>Título de la Gira</FormLabel><FormControl><Input placeholder="Ej: Visita a CoopeSoliDar R.L." {...field} /></FormControl><FormMessage /></FormItem> )} />
                         <FormField control={form.control} name="date" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><Calendar className="mr-2 h-4 w-4"/>Fecha</FormLabel><FormControl><Input placeholder="Ej: 25 de Octubre, 2024" {...field} /></FormControl><FormMessage /></FormItem> )} />
+                        <FormField control={form.control} name="dateISO" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><Calendar className="mr-2 h-4 w-4"/>Fecha ISO (YYYY-MM-DD)</FormLabel><FormControl><Input type="date" {...field} /></FormControl><FormDescription>Formato de fecha para recordatorios automáticos.</FormDescription><FormMessage /></FormItem> )} />
                         <FormField control={form.control} name="location" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><MapPin className="mr-2 h-4 w-4"/>Ubicación</FormLabel><FormControl><Input placeholder="Ej: Comunidad de CoopeSoliDar, Puntarenas" {...field} /></FormControl><FormMessage /></FormItem> )} />
                         <FormField control={form.control} name="status" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><Flag className="mr-2 h-4 w-4"/>Estado</FormLabel><Select onValueChange={field.onChange} defaultValue={field.value}><FormControl><SelectTrigger><SelectValue placeholder="Selecciona un estado" /></SelectTrigger></FormControl><SelectContent><SelectItem value="Próximamente">Próximamente</SelectItem><SelectItem value="Realizada">Realizada</SelectItem><SelectItem value="Cancelada">Cancelada</SelectItem></SelectContent></Select><FormMessage /></FormItem> )} />
                         <FormField control={form.control} name="description" render={({ field }) => ( <FormItem><FormLabel>Descripción</FormLabel><FormControl><Textarea placeholder="Describe los detalles, objetivos y actividades de la gira..." {...field} rows={6} /></FormControl><FormMessage /></FormItem> )} />

--- a/src/app/profesor/panel-giras/crear/page.tsx
+++ b/src/app/profesor/panel-giras/crear/page.tsx
@@ -140,6 +140,7 @@ export default function CrearGiraPage() {
           slug: slug,
           date: data.date,
           location: data.location,
+          imageUrl: coverImageUrl,
         }),
       }).catch(console.error);
 

--- a/src/app/profesor/panel-giras/crear/page.tsx
+++ b/src/app/profesor/panel-giras/crear/page.tsx
@@ -31,7 +31,7 @@ const tourSchema = z.object({
   location: z.string().min(3, { message: 'La ubicación es obligatoria.' }),
   date: z.string().min(1, { message: 'La fecha es obligatoria.' }),
   status: z.enum(['Próximamente', 'Realizada', 'Cancelada'], { required_error: 'Por favor selecciona un estado.' }),
-  dateISO: z.string().min(1, { message: 'La fecha ISO es obligatoria.' }),
+  dateISO: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, { message: 'La fecha debe estar en formato YYYY-MM-DD.' }),
   imageUrl: z
     .custom<FileList>()
     .refine((files) => files?.length === 1, "La imagen de portada es obligatoria.")

--- a/src/app/profesor/panel-giras/editar/[tourId]/page.tsx
+++ b/src/app/profesor/panel-giras/editar/[tourId]/page.tsx
@@ -33,6 +33,7 @@ const tourEditSchema = z.object({
   location: z.string().min(3, { message: 'La ubicación es obligatoria.' }),
   date: z.string().min(1, { message: 'La fecha es obligatoria.' }),
   status: z.enum(['Próximamente', 'Realizada', 'Cancelada'], { required_error: 'Por favor selecciona un estado.' }),
+  dateISO: z.string().optional(),
   imageUrl: z.custom<FileList>().optional(),
 });
 
@@ -107,6 +108,7 @@ export default function EditarGiraPage() {
               location: tourData.location,
               date: tourData.date,
               status: tourData.status,
+              dateISO: tourData.dateISO ?? '',
             });
           } else {
             setTourNotFound(true);
@@ -155,6 +157,7 @@ export default function EditarGiraPage() {
             location: data.location,
             date: data.date,
             status: data.status,
+            dateISO: data.dateISO,
             imageUrl: finalImageUrl,
             updatedAt: Timestamp.now(),
         };
@@ -200,6 +203,7 @@ export default function EditarGiraPage() {
             <CardContent className="space-y-8">
                 <FormField control={form.control} name="title" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><Info className="mr-2 h-4 w-4"/>Título de la Gira</FormLabel><FormControl><Input placeholder="Ej: Visita a CoopeSoliDar R.L." {...field} /></FormControl><FormMessage /></FormItem> )} />
                 <FormField control={form.control} name="date" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><Calendar className="mr-2 h-4 w-4"/>Fecha</FormLabel><FormControl><Input placeholder="Ej: 25 de Octubre, 2024" {...field} /></FormControl><FormMessage /></FormItem> )} />
+                <FormField control={form.control} name="dateISO" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><Calendar className="mr-2 h-4 w-4"/>Fecha ISO (YYYY-MM-DD)</FormLabel><FormControl><Input type="date" {...field} /></FormControl><FormDescription>Formato de fecha para recordatorios automáticos.</FormDescription><FormMessage /></FormItem> )} />
                 <FormField control={form.control} name="location" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><MapPin className="mr-2 h-4 w-4"/>Ubicación</FormLabel><FormControl><Input placeholder="Ej: Comunidad de CoopeSoliDar, Puntarenas" {...field} /></FormControl><FormMessage /></FormItem> )} />
                 <FormField control={form.control} name="status" render={({ field }) => ( <FormItem><FormLabel className="flex items-center"><Flag className="mr-2 h-4 w-4"/>Estado</FormLabel><Select onValueChange={field.onChange} value={field.value}><FormControl><SelectTrigger><SelectValue placeholder="Selecciona un estado" /></SelectTrigger></FormControl><SelectContent><SelectItem value="Próximamente">Próximamente</SelectItem><SelectItem value="Realizada">Realizada</SelectItem><SelectItem value="Cancelada">Cancelada</SelectItem></SelectContent></Select><FormMessage /></FormItem> )} />
                 <FormField control={form.control} name="description" render={({ field }) => ( <FormItem><FormLabel>Descripción</FormLabel><FormControl><Textarea placeholder="Describe los detalles, objetivos y actividades de la gira..." {...field} rows={6} /></FormControl><FormMessage /></FormItem> )} />

--- a/src/app/profesor/panel-proyectos/crear/page.tsx
+++ b/src/app/profesor/panel-proyectos/crear/page.tsx
@@ -219,6 +219,7 @@ function CrearProyectoClient() {
           title: data.name,
           description: data.description,
           slug: slug,
+          imageUrl: coverImageUrl,
         }),
       }).catch(console.error);
 

--- a/src/app/profesor/panel-proyectos/crear/page.tsx
+++ b/src/app/profesor/panel-proyectos/crear/page.tsx
@@ -209,7 +209,18 @@ function CrearProyectoClient() {
         updatedAt: Timestamp.now(),
       };
       
-      await addDoc(collection(db, 'projects'), projectDataToSave);
+      const docRef = await addDoc(collection(db, 'projects'), projectDataToSave);
+      fetch('/api/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 'project',
+          id: docRef.id,
+          title: data.name,
+          description: data.description,
+          slug: slug,
+        }),
+      }).catch(console.error);
 
       toast({
         title: "Proyecto Creado",

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -29,6 +29,21 @@ export async function postToTeams(payload: NotifyPayload): Promise<void> {
       return _exhaustiveCheck;
   }
 
+  // Build the body array dynamically
+  const body: object[] = [];
+  if (payload.imageUrl) {
+    body.push({
+      type: 'Image',
+      url: payload.imageUrl,
+      size: 'Large',
+      horizontalAlignment: 'Center',
+    });
+  }
+  body.push(
+    { type: 'TextBlock', size: 'Medium', weight: 'Bolder', text: payload.title },
+    { type: 'TextBlock', wrap: true, text: payload.description }
+  );
+
   // Build the Teams Adaptive Card
   const card = {
     type: 'message',
@@ -39,19 +54,7 @@ export async function postToTeams(payload: NotifyPayload): Promise<void> {
           $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
           type: 'AdaptiveCard',
           version: '1.2',
-          body: [
-            {
-              type: 'TextBlock',
-              size: 'Medium',
-              weight: 'Bolder',
-              text: payload.title,
-            },
-            {
-              type: 'TextBlock',
-              wrap: true,
-              text: payload.description,
-            },
-          ],
+          body,
           actions: [
             {
               type: 'Action.OpenUrl',

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -9,6 +9,9 @@ export async function postToTeams(payload: NotifyPayload): Promise<void> {
 
   // Build the page URL based on content type
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || '';
+  if (!siteUrl) {
+    console.warn('[notifications] NEXT_PUBLIC_SITE_URL is not set — Teams card links will be broken');
+  }
   let pageUrl: string;
 
   switch (payload.type) {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,81 @@
+import { NotifyPayload } from '@/types/notification';
+
+export async function postToTeams(payload: NotifyPayload): Promise<void> {
+  // Return early if Teams webhook is not configured
+  const webhookUrl = process.env.TEAMS_WEBHOOK_URL;
+  if (!webhookUrl) {
+    return;
+  }
+
+  // Build the page URL based on content type
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || '';
+  let pageUrl: string;
+
+  switch (payload.type) {
+    case 'tour':
+      pageUrl = `${siteUrl}/giras/${payload.slug}`;
+      break;
+    case 'article':
+      pageUrl = `${siteUrl}/anuncios`;
+      break;
+    case 'project':
+      pageUrl = `${siteUrl}/proyectos/${payload.slug}`;
+      break;
+    default:
+      const _exhaustiveCheck: never = payload;
+      return _exhaustiveCheck;
+  }
+
+  // Build the Teams Adaptive Card
+  const card = {
+    type: 'message',
+    attachments: [
+      {
+        contentType: 'application/vnd.microsoft.card.adaptive',
+        content: {
+          $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+          type: 'AdaptiveCard',
+          version: '1.2',
+          body: [
+            {
+              type: 'TextBlock',
+              size: 'Medium',
+              weight: 'Bolder',
+              text: payload.title,
+            },
+            {
+              type: 'TextBlock',
+              wrap: true,
+              text: payload.description,
+            },
+          ],
+          actions: [
+            {
+              type: 'Action.OpenUrl',
+              title: 'Ver más',
+              url: pageUrl,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(card),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Failed to post to Teams: ${response.status} ${response.statusText}`
+      );
+    }
+  } catch (error) {
+    console.error('Error posting to Teams:', error);
+  }
+}

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,4 +1,4 @@
 export type NotifyPayload =
-  | { type: 'tour'; id: string; title: string; description: string; slug: string; date: string; location: string }
-  | { type: 'article'; id: string; title: string; description: string }
-  | { type: 'project'; id: string; title: string; description: string; slug: string };
+  | { type: 'tour'; id: string; title: string; description: string; slug: string; date: string; location: string; imageUrl?: string }
+  | { type: 'article'; id: string; title: string; description: string; imageUrl?: string }
+  | { type: 'project'; id: string; title: string; description: string; slug: string; imageUrl?: string };

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,0 +1,4 @@
+export type NotifyPayload =
+  | { type: 'tour'; id: string; title: string; description: string; slug: string; date: string; location: string }
+  | { type: 'article'; id: string; title: string; description: string }
+  | { type: 'project'; id: string; title: string; description: string; slug: string };

--- a/src/types/tour.ts
+++ b/src/types/tour.ts
@@ -5,7 +5,6 @@ export interface FirestoreTour {
   slug: string;
   title: string;
   date: string; // Storing date as a string for simplicity, can be ISO string for proper sorting
-  dateISO?: string;
   status: 'Próximamente' | 'Realizada' | 'Cancelada';
   location: string;
   description: string;
@@ -13,4 +12,5 @@ export interface FirestoreTour {
   createdBy: string; // User UID
   createdAt: Timestamp;
   updatedAt: Timestamp;
+  dateISO?: string; // ISO 8601 date (YYYY-MM-DD) for cron-based reminder calculations
 }

--- a/src/types/tour.ts
+++ b/src/types/tour.ts
@@ -5,6 +5,7 @@ export interface FirestoreTour {
   slug: string;
   title: string;
   date: string; // Storing date as a string for simplicity, can be ISO string for proper sorting
+  dateISO?: string;
   status: 'Próximamente' | 'Realizada' | 'Cancelada';
   location: string;
   description: string;


### PR DESCRIPTION
This pull request introduces a system for sending Teams notifications and automated reminders for upcoming tours, along with significant improvements to project documentation and environment setup. The main changes include new API endpoints for notifications and reminders, integration of notifications when creating tours and articles, enforcement of machine-readable dates for tours, and a major overhaul of the `README.md` to provide clear setup and usage instructions.

**Automated notifications and reminders:**

* Added a new API endpoint at `/api/notify` to send notifications (for tours, articles, or projects) to Teams using the `postToTeams` utility. This endpoint validates payloads and swallows errors internally.
* Added a new API endpoint at `/api/send-reminders` that, when triggered (with proper authorization), queries for tours happening in 7 days, sends reminders to Teams, and marks them as sent to avoid duplicates.
* Created a GitHub Actions workflow (`.github/workflows/send-reminders.yml`) to call the `/api/send-reminders` endpoint daily at 8:00 AM Costa Rica time (14:00 UTC), using secrets for authentication and site URL.

**Integration of notifications on content creation:**

* When a new tour or article is created (in `profesor/panel-giras/crear` and `crear-anuncio` pages), a notification is automatically posted to Teams by calling the `/api/notify` endpoint with the relevant data. [[1]](diffhunk://#diff-ab854a066344abd5af93aea7abf94d13277ccf604647a4b2b2c9119ed6a0e4ebL127-R138) [[2]](diffhunk://#diff-30d70f2aaeac4c84f584e027c13d5e8b874714b9ca6cc0a931051d6258572ed1L129-R145)

**Tour date handling and validation:**

* Enforced the presence of a machine-readable ISO date (`dateISO`, format `YYYY-MM-DD`) for tours. The creation form now requires this field, and the backend uses it to determine which tours to send reminders for. [[1]](diffhunk://#diff-30d70f2aaeac4c84f584e027c13d5e8b874714b9ca6cc0a931051d6258572ed1R34) [[2]](diffhunk://#diff-30d70f2aaeac4c84f584e027c13d5e8b874714b9ca6cc0a931051d6258572ed1R92) [[3]](diffhunk://#diff-30d70f2aaeac4c84f584e027c13d5e8b874714b9ca6cc0a931051d6258572ed1L129-R145)

**Documentation and setup improvements:**

* Completely rewrote and expanded the `README.md` to include a quickstart guide, detailed environment setup, instructions for running emulators, backend, and frontend, API reference, environment variables, Teams notifications system, and usage examples for both local development and production. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R200) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R227) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L131-R342)

**Summary of most important changes:**

**Notifications and reminders system**
- Added `/api/notify` endpoint for sending Teams notifications for tours, articles, and projects.
- Added `/api/send-reminders` endpoint and scheduled GitHub Actions workflow to send Teams reminders for tours occurring in 7 days, with deduplication logic using Firestore. [[1]](diffhunk://#diff-bed4393883c55d7e689c88e5373e9bb316a3bf9e28ed1a87a32b9f07298e2515R1-R76) [[2]](diffhunk://#diff-3440c012a9a2b6f3ba2880233fc29b4e38e9a797b46beffe952fe8698d9f1a41R1-R19)

**Integration with content creation**
- Integrated notification sending into tour and article creation workflows, so a Teams notification is posted automatically when a new tour or article is created. [[1]](diffhunk://#diff-ab854a066344abd5af93aea7abf94d13277ccf604647a4b2b2c9119ed6a0e4ebL127-R138) [[2]](diffhunk://#diff-30d70f2aaeac4c84f584e027c13d5e8b874714b9ca6cc0a931051d6258572ed1L129-R145)

**Tour date validation**
- Required `dateISO` (YYYY-MM-DD) field for tours, enforced via form validation and used for reminders logic. [[1]](diffhunk://#diff-30d70f2aaeac4c84f584e027c13d5e8b874714b9ca6cc0a931051d6258572ed1R34) [[2]](diffhunk://#diff-30d70f2aaeac4c84f584e027c13d5e8b874714b9ca6cc0a931051d6258572ed1R92) [[3]](diffhunk://#diff-30d70f2aaeac4c84f584e027c13d5e8b874714b9ca6cc0a931051d6258572ed1L129-R145)

**Documentation and onboarding**
- Major rewrite of `README.md` to clarify setup, environment variables, usage, API, and notification/reminder systems, making onboarding and development much easier. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R200) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R227) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L131-R342)